### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ To use this library in your project, follow these general steps, as described fu
  pod 'MSOffice365-Discovery-SDK-iOS'
  ```
 
- > NOTE: For detailed information on Cocoapods and best practices for Podfiles, read the [Using Cocoapods] guide.
+ > NOTE: For detailed information on CocoaPods and best practices for Podfiles, read the [Using CocoaPods] guide.
 
 4. Close the Xcode project.
 
 5. From the command line, change to your project's directory. Then run `pod install`.
 
- > NOTE: Install Cocoapods first of course. Instructions [here](https://guides.cocoapods.org/using/getting-started.html).
+ > NOTE: Install CocoaPods first of course. Instructions [here](https://guides.cocoapods.org/using/getting-started.html).
 
 6. From the same location in the terminal, execute `open DiscoveryQuickStart.xcworkspace` to open a workspace containing your original project together with imported pods in Xcode.
 
@@ -114,7 +114,7 @@ With your project prepared, the next step is to initialize the dependency manage
 
 6. Now you can safely use the API client.
 
-[Using Cocoapods]: https://guides.cocoapods.org/using/using-cocoapods.html
+[Using CocoaPods]: https://guides.cocoapods.org/using/using-cocoapods.html
 [MSDN Add Common Consent]: https://msdn.microsoft.com/en-us/office/office365/howto/add-common-consent-manually
 
 ## Samples


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
